### PR TITLE
Update to Kotlin 1.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     java
-    kotlin("jvm") version "1.4.31"
+    kotlin("jvm") version "1.5.0"
     `maven-publish`
     jacoco
     id("com.github.kt3k.coveralls") version "2.10.2"

--- a/router/src/main/kotlin/io/moia/router/RequestHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/RequestHandler.kt
@@ -43,7 +43,7 @@ abstract class RequestHandler : RequestHandler<APIGatewayProxyRequestEvent, APIG
 
     override fun handleRequest(input: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent =
         input
-            .apply { headers = headers.mapKeys { it.key.toLowerCase() } }
+            .apply { headers = headers.mapKeys { it.key.lowercase() } }
             .let { router.filter.then(this::handleRequest)(it) }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
I am currently investigating a problem in our project with the `reflect()` call `RequestHandler.deserializeRequest()` returning null, thus causing a `NullPointerException`. As we just updated to Kotlin 1.5.0, I'd like to rule out a version incompatibility.

I added some smaller changes to move away from deprecated expressions as well, hope that's okay.