### PR TITLE
Kotlin 1.5.30 and plugin updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,11 +10,11 @@ buildscript {
 
 plugins {
     java
-    kotlin("jvm") version "1.4.31"
+    kotlin("jvm") version "1.5.30"
     `maven-publish`
     jacoco
     id("com.github.kt3k.coveralls") version "2.12.0"
-    id("org.jmailen.kotlinter") version "3.3.0"
+    id("org.jmailen.kotlinter") version "3.5.1"
 }
 
 group = "com.github.moia-dev"
@@ -25,8 +25,8 @@ repositories {
 }
 
 dependencies {
-    compile(kotlin("stdlib-jdk8"))
-    compile(kotlin("reflect"))
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 }
 
 subprojects {
@@ -42,14 +42,13 @@ subprojects {
 
     tasks {
         withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.jvmTarget = "11"
         }
 
         withType<Test> {
             useJUnitPlatform()
             testLogging.showStandardStreams = true
         }
-
     }
     
     publishing {

--- a/router-openapi-request-validator/build.gradle.kts
+++ b/router-openapi-request-validator/build.gradle.kts
@@ -3,11 +3,11 @@ repositories {
 }
 
 dependencies {
-    compile(kotlin("stdlib-jdk8"))
-    compile(kotlin("reflect"))
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 
-    compile("com.atlassian.oai:swagger-request-validator-core:2.15.1")
-    compile(project(":router"))
+    api("com.atlassian.oai:swagger-request-validator-core:2.15.1")
+    api(project(":router"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.1")
     testImplementation("org.assertj:assertj-core:3.19.0")

--- a/router-protobuf/build.gradle.kts
+++ b/router-protobuf/build.gradle.kts
@@ -10,14 +10,14 @@ repositories {
 }
 
 dependencies {
-    compile(kotlin("stdlib-jdk8"))
-    compile(kotlin("reflect"))
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 
-    compile("org.slf4j:slf4j-api:1.7.30")
-    compile("com.google.protobuf:protobuf-java:3.15.3")
-    compile("com.google.protobuf:protobuf-java-util:3.15.3")
-    compile("com.google.guava:guava:30.1-jre")
-    compile(project(":router"))
+    implementation("org.slf4j:slf4j-api:1.7.30")
+    api("com.google.protobuf:protobuf-java:3.15.3")
+    api("com.google.protobuf:protobuf-java-util:3.15.3")
+    implementation("com.google.guava:guava:30.1-jre")
+    api(project(":router"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.1")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.23.1")

--- a/router/build.gradle.kts
+++ b/router/build.gradle.kts
@@ -1,15 +1,15 @@
 
 
 dependencies {
-    compile(kotlin("stdlib-jdk8"))
-    compile(kotlin("reflect"))
-    compile("com.amazonaws:aws-lambda-java-core:1.2.1")
-    compile("com.amazonaws:aws-lambda-java-events:3.7.0")
-    
-    compile("org.slf4j:slf4j-api:1.7.30")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.12.1")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1")
-    compile("com.google.guava:guava:30.1-jre")
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
+    api("com.amazonaws:aws-lambda-java-core:1.2.1")
+    api("com.amazonaws:aws-lambda-java-events:3.7.0")
+
+    implementation("org.slf4j:slf4j-api:1.7.30")
+    api("com.fasterxml.jackson.core:jackson-databind:2.12.1")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1")
+    implementation("com.google.guava:guava:30.1-jre")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")

--- a/router/src/main/kotlin/io/moia/router/RequestHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/RequestHandler.kt
@@ -29,6 +29,7 @@ import com.google.common.net.MediaType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
+import kotlin.reflect.jvm.ExperimentalReflectionOnLambdas
 import kotlin.reflect.jvm.reflect
 
 @Suppress("UnstableApiUsage")
@@ -43,7 +44,7 @@ abstract class RequestHandler : RequestHandler<APIGatewayProxyRequestEvent, APIG
 
     override fun handleRequest(input: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent =
         input
-            .apply { headers = headers.mapKeys { it.key.toLowerCase() } }
+            .apply { headers = headers.mapKeys { it.key.lowercase() } }
             .let { router.filter.then(this::handleRequest)(it) }
 
     @Suppress("UNCHECKED_CAST")
@@ -117,6 +118,7 @@ abstract class RequestHandler : RequestHandler<APIGatewayProxyRequestEvent, APIG
     open fun permissionHandlerSupplier(): (r: APIGatewayProxyRequestEvent) -> PermissionHandler =
         { NoOpPermissionHandler() }
 
+    @ExperimentalReflectionOnLambdas
     private fun deserializeRequest(
         handler: HandlerFunction<Any, Any>,
         input: APIGatewayProxyRequestEvent


### PR DESCRIPTION
Compile scope is no longer available with gradle 7.2 and Kotlin 1.5 - so we need to choose between `api` and `implementation` now.

I am not sure if I got the choice between `api` and `implementation` right everywhere - so this could be breaking for consumers relying on a dependency coming in through the router lib. But this should be easy to fix...